### PR TITLE
chore: replaced swagger decorators in favour of the swagger plugin

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,5 +1,15 @@
 {
   "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "@nestjs/schematics",
-  "sourceRoot": "src"
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@nestjs/swagger/plugin",
+        "options": {
+          "introspectComments": true
+        }
+      }
+    ]
+  }
 }

--- a/backend/src/modules/organization/dto/create-contact.dto.ts
+++ b/backend/src/modules/organization/dto/create-contact.dto.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
 import {
   IsEmail,
   IsNotEmpty,
@@ -8,20 +7,17 @@ import {
 } from 'class-validator';
 
 export class CreateContactDto {
-  @ApiProperty()
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   fullName: string;
 
-  @ApiProperty()
   @IsString()
   @IsNotEmpty()
   @MaxLength(15)
   @MinLength(10)
   phone: string;
 
-  @ApiProperty()
   @IsEmail()
   @IsNotEmpty()
   @MaxLength(50)

--- a/backend/src/modules/organization/dto/create-organization-activity.dto.ts
+++ b/backend/src/modules/organization/dto/create-organization-activity.dto.ts
@@ -1,4 +1,3 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsArray,
   IsBoolean,
@@ -10,55 +9,43 @@ import {
 } from 'class-validator';
 
 export class CreateOrganizationActivityDto {
-  @ApiProperty()
   @IsBoolean()
   isPartOfFederation: boolean;
 
-  @ApiProperty()
   @IsArray()
   federations: string[];
 
-  @ApiProperty()
   @IsBoolean()
   isPartOfInternationalOrganization: boolean;
 
-  @ApiProperty()
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   internationalOrganizationName: string;
 
-  @ApiProperty()
   @IsBoolean()
   isSocialServiceViable: boolean;
 
-  @ApiProperty()
   @IsBoolean()
   offersGrants: boolean;
 
-  @ApiProperty()
   @IsBoolean()
   isPublicIntrestOrganization: boolean;
 
-  @ApiProperty()
   @IsBoolean()
   hasBranches: boolean;
 
-  @ApiPropertyOptional()
   @IsOptional()
   @IsNumber()
   @IsArray()
   branches?: number[];
 
-  @ApiProperty()
   @IsNumber()
   areaId: number;
 
-  @ApiProperty()
   @IsArray()
   domains: number[];
 
-  @ApiProperty()
   @IsArray()
   cities: number[];
 }

--- a/backend/src/modules/organization/dto/create-organization-financial.dto.ts
+++ b/backend/src/modules/organization/dto/create-organization-financial.dto.ts
@@ -1,16 +1,12 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { IsNumber } from 'class-validator';
 
 export class CreateOrganizationFinancialDto {
-  @ApiProperty()
   @IsNumber()
   numberOfEmployees: number;
 
-  @ApiProperty()
   @IsNumber()
   totalIncome: number;
 
-  @ApiProperty()
   @IsNumber()
   totalExpenses: number;
 }

--- a/backend/src/modules/organization/dto/create-organization-general.dto.ts
+++ b/backend/src/modules/organization/dto/create-organization-general.dto.ts
@@ -1,4 +1,3 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsEmail,
@@ -16,88 +15,54 @@ import {
 import { CreateContactDto } from 'src/modules/organization/dto/create-contact.dto';
 import { OrganizationType } from '../enums/organization-type.enum';
 export class CreateOrganizationGeneralDto {
-  @ApiProperty({
-    description: 'Organization name',
-    maxLength: 100,
-    required: true,
-  })
+  /* Organization name */
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   name: string;
 
-  @ApiProperty({
-    description: 'Organization alias',
-    maxLength: 50,
-  })
+  /* Organization alias */
   @IsString()
   @IsNotEmpty()
   @MaxLength(50)
   alias: string;
 
-  @ApiProperty({
-    description: 'Organization type',
-    enum: OrganizationType,
-    enumName: 'OrganizationType',
-  })
+  /* Organization type */
   @IsEnum(OrganizationType)
   type: OrganizationType;
 
-  @ApiProperty({
-    description: 'Organization email',
-    maxLength: 50,
-  })
+  /* Organization email */
   @IsEmail()
   @IsNotEmpty()
   @MaxLength(50)
   email: string;
 
-  @ApiProperty({
-    description: 'Organization year created',
-    minimum: 1900,
-    maximum: 2022,
-  })
+  /* Organization year created */
   @Min(1900)
   @Max(2022)
   @IsNumber()
   yearCreated: number;
 
-  @ApiProperty({
-    description: 'Organization CUI/CIF',
-    maxLength: 12,
-    minLength: 2,
-  })
+  /* Organization CUI/CIF */
   @IsString()
   @MaxLength(12)
   @MinLength(2)
   cui: string;
 
-  @ApiProperty({
-    description: 'Organization Register of Associations and Foundations Number',
-    maxLength: 12,
-    minLength: 2,
-  })
+  /* Organization Register of Associations and Foundations Number */
   @IsString()
   @MaxLength(12)
   @MinLength(2)
   rafNumber: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization short description',
-    maxLength: 250,
-    minLength: 200,
-  })
+  /* Organization short description */
   @IsString()
   @IsOptional()
   @MinLength(200)
   @MaxLength(250)
   shortDescription?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization long description',
-    maxLength: 300,
-    minLength: 250,
-  })
+  /* Organization long description */
   @IsString()
   @IsOptional()
   @MinLength(250)
@@ -105,99 +70,70 @@ export class CreateOrganizationGeneralDto {
   description?: string;
 
   // TODO: this should be removed once we have the attachment table
-  @ApiProperty({
-    description: 'Organization logo/link',
-  })
+  /* Organization logo/link */
   @IsString()
   logo: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization website',
-  })
+  /* Organization website */
   @IsString()
   @IsOptional()
   website?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization facbook',
-  })
+  /* Organization facebook */
   @IsString()
   @IsOptional()
   facebook?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization instagram',
-  })
+  /* Organization instagram */
   @IsString()
   @IsOptional()
   instagram?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization twitter',
-  })
+  /* Organization twitter */
   @IsString()
   @IsOptional()
   twitter?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization linkedin',
-  })
+  /* Organization linkedin */
   @IsString()
   @IsOptional()
   linkedin?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization tiktok',
-  })
+  /* Organization tiktok */
   @IsString()
   @IsOptional()
   tiktok?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization donation website',
-  })
+  /* Organization donation website */
   @IsString()
   @IsOptional()
   donationWebsite?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization donation redirect link',
-  })
+  /* Organization donation redirect link */
   @IsString()
   @IsOptional()
   redirectLink?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization donation sms number',
-  })
+  /* Organization donation sms number */
   @IsString()
   @IsOptional()
-  donationSMS: string;
+  donationSMS?: string;
 
-  @ApiPropertyOptional({
-    description: 'Organization donation keyword',
-  })
+  /* Organization donation keyword */
   @IsString()
   @IsOptional()
-  donationKeyword: string;
+  donationKeyword?: string;
 
-  @ApiProperty({
-    description: 'Organization contact person',
-    type: () => CreateContactDto,
-  })
+  /* Organization contact person */
   @Type(() => CreateContactDto)
   @ValidateNested()
   contact: CreateContactDto;
 
-  @ApiProperty({
-    description: 'Organization county id',
-  })
+  /* Organization county id */
   @IsNumber()
   countyId: number;
 
-  @ApiProperty({
-    description: 'Organization city id',
-  })
+  /* Organization city id */
   @IsNumber()
   cityId: number;
 }

--- a/backend/src/modules/organization/dto/create-organization-legal.dto.ts
+++ b/backend/src/modules/organization/dto/create-organization-legal.dto.ts
@@ -1,39 +1,27 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { Person } from 'src/modules/organization/dto/person.dto';
 import { CreateContactDto } from 'src/modules/organization/dto/create-contact.dto';
 
 export class CreateOrganizationLegalDto {
-  @ApiProperty({
-    description: 'Organization legal representative',
-    type: () => CreateContactDto,
-  })
+  /* Organization legal representative */
   @Type(() => CreateContactDto)
   @ValidateNested()
   legalReprezentative: CreateContactDto;
 
-  @ApiProperty({
-    description: 'Organization directors',
-    type: () => [CreateContactDto],
-  })
+  /* Organization directors */
   @Type(() => CreateContactDto)
   @ValidateNested()
   directors: CreateContactDto[];
 
-  @ApiPropertyOptional({
-    description: 'Other relevant persons in organization',
-    type: [Person],
-  })
+  /* Other relevant persons in organization */
   @IsOptional()
   @IsArray()
   @ValidateNested()
   @Type(() => Person)
-  others: Person[];
+  others?: Person[];
 
-  @ApiPropertyOptional({
-    description: 'Organization statute link',
-  })
+  /* Organization statute link */
   @IsOptional()
   @IsString()
   organizationStatute?: string;

--- a/backend/src/modules/organization/dto/create-organization-report.dto.ts
+++ b/backend/src/modules/organization/dto/create-organization-report.dto.ts
@@ -1,38 +1,26 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsArray, IsNumber, IsOptional, ValidateNested } from 'class-validator';
 import { Investor } from './inverstor.dto';
 import { Report } from './report.dto';
 
 export class CreateOrganizationReportDto {
-  @ApiProperty()
   @IsNumber()
   numberOfVolunteers: number;
 
-  @ApiProperty()
   @IsNumber()
   numberOfContractors: number;
 
-  @ApiPropertyOptional({
-    type: () => [Report],
-  })
   @IsOptional()
   @IsArray()
   @ValidateNested()
   @Type(() => Report)
   reports?: Report[];
 
-  @ApiPropertyOptional({
-    type: [Investor],
-  })
   @Type(() => Investor)
   @IsOptional()
   @IsArray()
   donors?: Investor[];
 
-  @ApiPropertyOptional({
-    type: [Investor],
-  })
   @Type(() => Investor)
   @IsOptional()
   @IsArray()

--- a/backend/src/modules/organization/dto/create-organization.dto.ts
+++ b/backend/src/modules/organization/dto/create-organization.dto.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { ValidateNested } from 'class-validator';
 import { CreateOrganizationActivityDto } from './create-organization-activity.dto';
@@ -7,42 +6,27 @@ import { CreateOrganizationGeneralDto } from './create-organization-general.dto'
 import { CreateOrganizationLegalDto } from './create-organization-legal.dto';
 import { CreateOrganizationReportDto } from './create-organization-report.dto';
 export class CreateOrganizationDto {
-  @ApiProperty({
-    description: 'Organization General',
-    type: () => CreateOrganizationGeneralDto,
-  })
+  /* Organization General */
   @Type(() => CreateOrganizationGeneralDto)
   @ValidateNested()
   general: CreateOrganizationGeneralDto;
 
-  @ApiProperty({
-    description: 'Organization Activity',
-    type: () => CreateOrganizationActivityDto,
-  })
+  /* Organization Activity */
   @Type(() => CreateOrganizationActivityDto)
   @ValidateNested()
   activity: CreateOrganizationActivityDto;
 
-  @ApiProperty({
-    description: 'Organization Legal',
-    type: () => CreateOrganizationLegalDto,
-  })
+  /* Organization Legal */
   @Type(() => CreateOrganizationLegalDto)
   @ValidateNested()
   legal: CreateOrganizationLegalDto;
 
-  @ApiProperty({
-    description: 'Organization Financial',
-    type: () => CreateOrganizationFinancialDto,
-  })
+  /* Organization Financial */
   @Type(() => CreateOrganizationFinancialDto)
   @ValidateNested()
   financial: CreateOrganizationFinancialDto;
 
-  @ApiProperty({
-    description: 'Organization Report',
-    type: () => CreateOrganizationReportDto,
-  })
+  /* Organization Report */
   @Type(() => CreateOrganizationReportDto)
   @ValidateNested()
   report: CreateOrganizationReportDto;

--- a/backend/src/modules/organization/dto/inverstor.dto.ts
+++ b/backend/src/modules/organization/dto/inverstor.dto.ts
@@ -1,9 +1,9 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsString } from 'class-validator';
 
 export class Investor {
-  @ApiProperty()
+  @IsString()
   name: string;
 
-  @ApiProperty()
+  @IsArray()
   years: number[];
 }

--- a/backend/src/modules/organization/dto/person.dto.ts
+++ b/backend/src/modules/organization/dto/person.dto.ts
@@ -1,9 +1,9 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
 
 export class Person {
-  @ApiProperty()
+  @IsString()
   fullName: string;
 
-  @ApiProperty()
+  @IsString()
   role: string;
 }

--- a/backend/src/modules/organization/dto/report.dto.ts
+++ b/backend/src/modules/organization/dto/report.dto.ts
@@ -1,9 +1,9 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString } from 'class-validator';
 
 export class Report {
-  @ApiProperty()
+  @IsString()
   link: string;
 
-  @ApiProperty()
+  @IsNumber()
   year: number;
 }

--- a/backend/src/modules/organization/dto/update-contact.dto.ts
+++ b/backend/src/modules/organization/dto/update-contact.dto.ts
@@ -1,9 +1,8 @@
-import { ApiPropertyOptional, PartialType } from '@nestjs/swagger';
+import { PartialType } from '@nestjs/swagger';
 import { IsNumber } from 'class-validator';
 import { CreateContactDto } from './create-contact.dto';
 
 export class UpdateContactDto extends PartialType(CreateContactDto) {
-  @ApiPropertyOptional()
   @IsNumber()
-  id: number;
+  id?: number;
 }

--- a/backend/src/modules/organization/dto/update-organization-general.dto.ts
+++ b/backend/src/modules/organization/dto/update-organization-general.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType, OmitType, ApiPropertyOptional } from '@nestjs/swagger';
+import { PartialType, OmitType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsOptional, ValidateNested } from 'class-validator';
 import { UpdateContactDto } from 'src/modules/organization/dto/update-contact.dto';
@@ -7,11 +7,8 @@ import { CreateOrganizationGeneralDto } from './create-organization-general.dto'
 export class UpdateOrganizationGeneralDto extends PartialType(
   OmitType(CreateOrganizationGeneralDto, ['contact']),
 ) {
+  /* Organization contact person */
   @IsOptional()
-  @ApiPropertyOptional({
-    description: 'Organization contact person',
-    type: () => UpdateContactDto,
-  })
   @Type(() => UpdateContactDto)
   @ValidateNested()
   contact?: UpdateContactDto;

--- a/backend/src/modules/organization/dto/update-organization-legal.dto.ts
+++ b/backend/src/modules/organization/dto/update-organization-legal.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType, OmitType, ApiPropertyOptional } from '@nestjs/swagger';
+import { PartialType, OmitType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsOptional, ValidateNested } from 'class-validator';
 import { UpdateContactDto } from 'src/modules/organization/dto/update-contact.dto';
@@ -8,21 +8,15 @@ import { UpsertContactDto } from './upsert-contact.dto';
 export class UpdateOrganizationLegalDto extends PartialType(
   OmitType(CreateOrganizationLegalDto, ['directors', 'legalReprezentative']),
 ) {
-  @ApiPropertyOptional({
-    description: 'Organization legal representative',
-    type: () => UpdateContactDto,
-  })
+  /* Organization legal representative */
   @IsOptional()
   @Type(() => UpdateContactDto)
   @ValidateNested()
   legalReprezentative?: UpdateContactDto;
 
-  @ApiPropertyOptional({
-    description: 'Organization directors',
-    type: () => [UpdateContactDto],
-  })
+  /* Organization directors */
   @IsOptional()
   @Type(() => UpsertContactDto)
   @ValidateNested()
-  directors: UpsertContactDto[];
+  directors?: UpsertContactDto[];
 }

--- a/backend/src/modules/organization/dto/update-organization.dto.ts
+++ b/backend/src/modules/organization/dto/update-organization.dto.ts
@@ -1,4 +1,3 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsOptional, ValidateNested } from 'class-validator';
 import { UpdateOrganizationActivityDto } from './update-organization-activity.dto';
@@ -8,45 +7,33 @@ import { UpdateOrganizationLegalDto } from './update-organization-legal.dto';
 import { UpdateOrganizationReportDto } from './update-organization-report.dto';
 
 export class UpdateOrganizationDto {
-  @ApiPropertyOptional({
-    description: 'Organization General',
-  })
+  /* Organization General */
   @IsOptional()
   @Type(() => UpdateOrganizationGeneralDto)
   @ValidateNested()
-  general: UpdateOrganizationGeneralDto;
+  general?: UpdateOrganizationGeneralDto;
 
-  @ApiPropertyOptional({
-    description: 'Organization Activity',
-  })
+  /* Organization Activity */
   @IsOptional()
   @Type(() => UpdateOrganizationActivityDto)
   @ValidateNested()
-  activity: UpdateOrganizationActivityDto;
+  activity?: UpdateOrganizationActivityDto;
 
-  @ApiPropertyOptional({
-    description: 'Organization Legal',
-  })
+  /* Organization Legal */
   @IsOptional()
   @Type(() => UpdateOrganizationLegalDto)
   @ValidateNested()
-  legal: UpdateOrganizationLegalDto;
+  legal?: UpdateOrganizationLegalDto;
 
-  @ApiPropertyOptional({
-    description: 'Organization Financial',
-    type: () => UpdateOrganizationFinancialDto,
-  })
+  /* Organization Financial */
   @IsOptional()
   @Type(() => UpdateOrganizationFinancialDto)
   @ValidateNested()
-  financial: UpdateOrganizationFinancialDto;
+  financial?: UpdateOrganizationFinancialDto;
 
-  @ApiPropertyOptional({
-    description: 'Organization Report',
-    type: () => UpdateOrganizationReportDto,
-  })
+  /* Organization Report */
   @IsOptional()
   @Type(() => UpdateOrganizationReportDto)
   @ValidateNested()
-  report: UpdateOrganizationReportDto;
+  report?: UpdateOrganizationReportDto;
 }


### PR DESCRIPTION
This change reduced the current and will reduce the future boilerplate, especially when more entities and dtos will be added.
Only the @ApiHideProperty decorator will be used if some properties need to be hidden.
If a description wants to be added to the property, a comment will be left above it with the desired text.