### PR TITLE
fix[C4R-335] Hidden Popover on Data Table

### DIFF
--- a/frontend/src/components/data-table/DataTableComponent.tsx
+++ b/frontend/src/components/data-table/DataTableComponent.tsx
@@ -36,7 +36,12 @@ const DataTableComponent = ({
   const { i18n } = useLingui();
 
   return (
-    <div className={classNames(!loading && data.length > 0 ? 'border-b border-gray-200' : '')}>
+    <div
+      className={classNames(
+        !loading && data.length > 0 ? 'border-b border-gray-200' : '',
+        'rdt_TableWrapper',
+      )}
+    >
       <DataTable
         noHeader
         columns={columns}

--- a/frontend/src/components/popover-menu/PopoverMenu.tsx
+++ b/frontend/src/components/popover-menu/PopoverMenu.tsx
@@ -44,7 +44,7 @@ const PopoverMenu = ({ row, menuItems }: MenuProps) => {
             leaveFrom="opacity-100 translate-y-0"
             leaveTo="opacity-0 translate-y-1"
           >
-            <Popover.Panel className="absolute z-10 left-1/2 transform -translate-x-3/4 mt-2 px-0 w-56 max-w-sm">
+            <Popover.Panel className="absolute z-10 left-1 transform -translate-x-3/4 mt-2 px-0 w-56 max-w-sm">
               <div className="rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
                 <div className="relative grid gap-4 bg-white py-4 px-5">
                   {menuItems.map((item) => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -62,7 +62,7 @@
 }
 
 /* Overrride default overflow for datatables to allow popovers */
-.gelpCx {
+.rdt_TableWrapper div {
   overflow-x: initial !important;
   overflow-y: initial !important;
 }


### PR DESCRIPTION
Link: https://wearetribus.atlassian.net/jira/software/c/projects/C4R/boards/6?modal=detail&selectedIssue=C4R-335&assignee=60f9333a9f975e0069d2df9e

 - Override table overflow styling for popovers