### PR TITLE
bugfix: [C4R-761] Generate reporting entries for last year by default

### DIFF
--- a/backend/src/modules/organization/controllers/organization.controller.ts
+++ b/backend/src/modules/organization/controllers/organization.controller.ts
@@ -285,8 +285,25 @@ export class OrganizationController {
 
   @Roles(Role.SUPER_ADMIN)
   @ApiParam({ name: 'id', type: String })
+  @ApiBody({
+    required: false,
+    schema: {
+      type: 'object',
+      required: [],
+      properties: {
+        forYear: {
+          type: 'number',
+          format: 'int32',
+          minimum: 2020,
+        },
+      },
+    },
+  })
   @Post(':id/new-report-entries')
-  createNewReportEntries(@Param('id') id: string) {
-    return this.organizationService.createNewReportingEntries(id);
+  createNewReportEntries(
+    @Param('id') id: string,
+    @Body() { forYear }: { forYear: number },
+  ) {
+    return this.organizationService.createNewReportingEntries(id, forYear);
   }
 }

--- a/backend/src/modules/organization/services/organization.service.ts
+++ b/backend/src/modules/organization/services/organization.service.ts
@@ -1126,8 +1126,11 @@ export class OrganizationService {
    *  2. Create 3 new entires for Reports, Parteners, Investors (Open Data)
    *  3. Send notification email to the NGO Admin to take action
    */
-  public async createNewReportingEntries(organizationId: string) {
-    const year = new Date().getFullYear() - 2;
+  public async createNewReportingEntries(
+    organizationId: string,
+    forYear?: number,
+  ) {
+    const year = forYear ?? new Date().getFullYear() - 1;
     // 1. Check if the NGO already has the data we try to add
     const organization = await this.findWithRelations(+organizationId);
 


### PR DESCRIPTION
- Generate reporting entries for last year by default (it was -2 years)
- add "forYear" parameter to the API (now can be called with ```{ forYear: 2020 }```