### PR TITLE
fix 509: navigate back to applications when app req returns an error

### DIFF
--- a/frontend/src/pages/application/Application.tsx
+++ b/frontend/src/pages/application/Application.tsx
@@ -4,6 +4,7 @@ import { Outlet, useNavigate, useParams } from 'react-router-dom';
 import ContentWrapper from '../../components/content-wrapper/ContentWrapper';
 import { Loading } from '../../components/loading/Loading';
 import { useApplicationQuery } from '../../services/application/Application.queries';
+import { useErrorToast } from '../../common/hooks/useToast';
 
 const Application = () => {
   const navigate = useNavigate();
@@ -23,6 +24,8 @@ const Application = () => {
 
   if (error) {
     navigate('/applications');
+    useErrorToast(t('wrong', { ns: 'common' }));
+    return null;
   }
 
   const navigateBack = () => {


### PR DESCRIPTION
Because we were not returning anything, the browser was still trying to get us to the details page while trying to navigate to /applications.

[Cannot update a component while rendering a different component warning]