### PR TITLE
fix 511: financial data error translations

### DIFF
--- a/frontend/src/assets/locales/en/translation.json
+++ b/frontend/src/assets/locales/en/translation.json
@@ -695,7 +695,11 @@
         "label": "Other expenses",
         "info": "Enter here the total of any other expenses you have not entered in other segments of this budget (for example the purchase of a trailer for a caravan etc.)."
       }
-    }
+    },
+    "retry_anaf_warning": "Your data is not up to date.",
+    "retry_anaf_button": "Try again",
+    "retry_anaf_error": "Service unavailable.",
+    "no_financial_info": "No data available for your request."
   },
   "open_data": {
     "load_error": "Data could not be uploaded",

--- a/frontend/src/assets/locales/ro/translation.json
+++ b/frontend/src/assets/locales/ro/translation.json
@@ -698,7 +698,11 @@
         "label": "Alte cheltuieli",
         "info": "Introduci aici totalul oricăror altor cheltuieli pe care nu le-ai trecut in alte segmente ale acestui buget (de exemplu achiziția unei rulote pentru o caravana etc.)."
       }
-    }
+    },
+    "retry_anaf_warning": "Datele nu au fost actualizate.",
+    "retry_anaf_button": "Încearcă din nou",
+    "retry_anaf_error": "Service unavailable.",
+    "no_financial_info": "Nu există date pentru solicitarea dumneavoastră."
   },
   "open_data": {
     "load_error": "Datele nu s-au putut încărca",

--- a/frontend/src/assets/locales/ro/translation.json
+++ b/frontend/src/assets/locales/ro/translation.json
@@ -701,7 +701,7 @@
     },
     "retry_anaf_warning": "Datele nu au fost actualizate.",
     "retry_anaf_button": "Încearcă din nou",
-    "retry_anaf_error": "Service unavailable.",
+    "retry_anaf_error": "Serviciu momentan indisponibil.",
     "no_financial_info": "Nu există date pentru solicitarea dumneavoastră."
   },
   "open_data": {

--- a/frontend/src/pages/organization/components/OrganizationFinancial/OrganizationFinancial.tsx
+++ b/frontend/src/pages/organization/components/OrganizationFinancial/OrganizationFinancial.tsx
@@ -82,19 +82,21 @@ const OrganizationFinancial = () => {
 
   const onUpdateAnaf = () => {
     if (organization && organizationGeneral?.cui) {
-      retryAnaf({ organizationId: organization?.id, cui: organizationGeneral?.cui }, {
-        onSuccess: (data) => {
-          if (data[0].synched_anaf === false) {
+      retryAnaf(
+        { organizationId: organization?.id, cui: organizationGeneral?.cui },
+        {
+          onSuccess: (data) => {
+            if (data[0].synched_anaf === false) {
+              useErrorToast(t('no_financial_info'));
+            }
+          },
+          onError: () => {
             useErrorToast(t('retry_anaf_error'));
-          }
+          },
         },
-        onError: () => {
-          useErrorToast(t('retry_anaf_error'));
-        }
-      });
+      );
     }
-  }
-
+  };
 
   const onView = (row: IOrganizationFinancial) => {
     setSelectedReport(row);
@@ -135,21 +137,26 @@ const OrganizationFinancial = () => {
             {t('data_update', { ns: 'financial' })}
           </p>
         </div>
-        {organization?.status === OrganizationStatus.PENDING && organizationFinancial[0].synched_anaf === false && role == UserRole.SUPER_ADMIN && (
-          <div className='flex my-2 gap-4 items-center flex-column'>
-            <p className='flex'>
-              <span className='text-yellow-900 sm:text-sm lg:text-base text-xs font-normal'>{t('retry_anaf_warning')}&nbsp;</span>
-            </p>
-            <button
-              aria-label={t('retry_anaf_button')}
-              className="edit-button flex gap-4 justify-center disabled:bg-gray-50"
-              onClick={onUpdateAnaf}
-              disabled={false}
-            >
-              {t('retry_anaf_button')}
-            </button>
-            {isLoadinAnaf && <LoadingContent />}
-          </div>)}
+        {organization?.status === OrganizationStatus.PENDING &&
+          organizationFinancial[0].synched_anaf === false &&
+          role == UserRole.SUPER_ADMIN && (
+            <div className="flex my-2 gap-4 items-center flex-column">
+              <p className="flex">
+                <span className="text-yellow-900 sm:text-sm lg:text-base text-xs font-normal">
+                  {t('retry_anaf_warning')}&nbsp;
+                </span>
+              </p>
+              <button
+                aria-label={t('retry_anaf_button')}
+                className="edit-button flex gap-4 justify-center disabled:bg-gray-50"
+                onClick={onUpdateAnaf}
+                disabled={false}
+              >
+                {t('retry_anaf_button')}
+              </button>
+              {isLoadinAnaf && <LoadingContent />}
+            </div>
+          )}
         <DataTableComponent
           columns={[...OrganizationFinancialTableHeaders, buildActionColumn()]}
           data={organizationFinancial}


### PR DESCRIPTION
Regarding the ANAF endpoint subject of this issue, it seems that the actual problem is not the endpoint, but the fact the the CUI for the request does not exist. 

ANAF does not return an error in this case, but we check further even if the req was successful to see if the data is synced. In case it is not synced, we show the error toast. 

Question: should we enforce some sort of CUI validation on organisation creation? 