### PR TITLE
feat: allow SuperAdmins to view all users

### DIFF
--- a/backend/src/migrations/1721741119685-AddOrganizationAliasToUserApplicationsView.ts
+++ b/backend/src/migrations/1721741119685-AddOrganizationAliasToUserApplicationsView.ts
@@ -1,0 +1,84 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrganizationAliasToUserApplicationsView1721741119685
+  implements MigrationInterface
+{
+  name = 'AddOrganizationAliasToUserApplicationsView1721741119685';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['VIEW', 'UserApplicationsView', 'public'],
+    );
+    await queryRunner.query(`DROP VIEW "UserApplicationsView"`);
+    await queryRunner.query(`CREATE VIEW "UserApplicationsView" AS 
+      SELECT u.id,
+          u.name,
+          u.email,
+          u.phone,
+          u.status,
+          u.role,
+          u.organization_id AS "organizationId",
+          u.created_on AS "createdOn",
+          u.updated_on AS "updatedOn",
+          og.alias as "organizationAlias",
+          array_agg(DISTINCT a.id) AS "availableAppsIDs",
+          json_agg(DISTINCT jsonb_build_object('id', a.id, 'name', a.name, 'type', a.type)) AS "availableApps"
+        FROM "user" u
+          LEFT JOIN user_ong_application uoa ON u.id = uoa.user_id AND uoa.status = 'active'::user_ong_application_status_enum
+          LEFT JOIN ong_application oa ON uoa.ong_application_id = oa.id AND oa.status = 'active'::ong_application_status_enum
+          LEFT JOIN application a ON (oa.application_id = a.id OR a.type = 'independent'::application_type_enum) AND a.status = 'active'::application_status_enum
+          LEFT JOIN organization o ON u.organization_id = o.id
+          LEFT JOIN organization_general og ON o.organization_general_id = og.id
+      WHERE u.role = 'employee'::user_role_enum AND (u.status = ANY (ARRAY['active'::user_status_enum, 'restricted'::user_status_enum])) AND u.deleted_on IS NULL
+      GROUP BY u.id, og.alias;
+
+  `);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'VIEW',
+        'UserApplicationsView',
+        "SELECT u.id,\n          u.name,\n          u.email,\n          u.phone,\n          u.status,\n          u.role,\n          u.organization_id AS \"organizationId\",\n          u.created_on AS \"createdOn\",\n          u.updated_on AS \"updatedOn\",\n          og.alias as \"organizationAlias\",\n          array_agg(DISTINCT a.id) AS \"availableAppsIDs\",\n          json_agg(DISTINCT jsonb_build_object('id', a.id, 'name', a.name, 'type', a.type)) AS \"availableApps\"\n        FROM \"user\" u\n          LEFT JOIN user_ong_application uoa ON u.id = uoa.user_id AND uoa.status = 'active'::user_ong_application_status_enum\n          LEFT JOIN ong_application oa ON uoa.ong_application_id = oa.id AND oa.status = 'active'::ong_application_status_enum\n          LEFT JOIN application a ON (oa.application_id = a.id OR a.type = 'independent'::application_type_enum) AND a.status = 'active'::application_status_enum\n          LEFT JOIN organization o ON u.organization_id = o.id\n          LEFT JOIN organization_general og ON o.organization_general_id = og.id\n      WHERE u.role = 'employee'::user_role_enum AND (u.status = ANY (ARRAY['active'::user_status_enum, 'restricted'::user_status_enum])) AND u.deleted_on IS NULL\n      GROUP BY u.id, og.alias;",
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['VIEW', 'UserApplicationsView', 'public'],
+    );
+    await queryRunner.query(`DROP VIEW "UserApplicationsView"`);
+    await queryRunner.query(`CREATE VIEW "UserApplicationsView" AS SELECT u.id,
+          u.name,
+          u.email,
+          u.phone,
+          u.status,
+          u.role,
+          u.organization_id AS "organizationId",
+          u.created_on AS "createdOn",
+          u.updated_on AS "updatedOn",
+          og.alias,
+          array_agg(DISTINCT a.id) AS "availableAppsIDs",
+          json_agg(DISTINCT jsonb_build_object('id', a.id, 'name', a.name, 'type', a.type)) AS "availableApps"
+        FROM "user" u
+          LEFT JOIN user_ong_application uoa ON u.id = uoa.user_id AND uoa.status = 'active'::user_ong_application_status_enum
+          LEFT JOIN ong_application oa ON uoa.ong_application_id = oa.id AND oa.status = 'active'::ong_application_status_enum
+          LEFT JOIN application a ON (oa.application_id = a.id OR a.type = 'independent'::application_type_enum) AND a.status = 'active'::application_status_enum
+          LEFT JOIN organization o ON u.organization_id = o.id
+          LEFT JOIN organization_general og ON o.organization_general_id = og.id
+      WHERE u.role = 'employee'::user_role_enum AND (u.status = ANY (ARRAY['active'::user_status_enum, 'restricted'::user_status_enum])) AND u.deleted_on IS NULL
+      GROUP BY u.id, og.alias;`);
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'VIEW',
+        'UserApplicationsView',
+        "SELECT u.id,\n          u.name,\n          u.email,\n          u.phone,\n          u.status,\n          u.role,\n          u.organization_id AS \"organizationId\",\n          u.created_on AS \"createdOn\",\n          u.updated_on AS \"updatedOn\",\n          og.alias,\n          array_agg(DISTINCT a.id) AS \"availableAppsIDs\",\n          json_agg(DISTINCT jsonb_build_object('id', a.id, 'name', a.name, 'type', a.type)) AS \"availableApps\"\n        FROM \"user\" u\n          LEFT JOIN user_ong_application uoa ON u.id = uoa.user_id AND uoa.status = 'active'::user_ong_application_status_enum\n          LEFT JOIN ong_application oa ON uoa.ong_application_id = oa.id AND oa.status = 'active'::ong_application_status_enum\n          LEFT JOIN application a ON (oa.application_id = a.id OR a.type = 'independent'::application_type_enum) AND a.status = 'active'::application_status_enum\n          LEFT JOIN organization o ON u.organization_id = o.id\n          LEFT JOIN organization_general og ON o.organization_general_id = og.id\n      WHERE u.role = 'employee'::user_role_enum AND (u.status = ANY (ARRAY['active'::user_status_enum, 'restricted'::user_status_enum])) AND u.deleted_on IS NULL\n      GROUP BY u.id, og.alias;",
+      ],
+    );
+  }
+}

--- a/backend/src/modules/organization/services/organization.service.ts
+++ b/backend/src/modules/organization/services/organization.service.ts
@@ -325,14 +325,6 @@ export class OrganizationService {
       paginationOptions,
     );
 
-    for (let index in ongList.items) {
-      const data = await this.findWithRelations(ongList.items[index].id);
-      ongList.items[index] = {
-        ...ongList.items[index],
-        ...data,
-      };
-    }
-
     // Map the logo url
     const items =
       await this.fileManagerService.mapLogoToEntity<OrganizationView>(

--- a/backend/src/modules/user/constants/invites-filters.config.ts
+++ b/backend/src/modules/user/constants/invites-filters.config.ts
@@ -7,10 +7,21 @@ export const INVITE_FILTERS_CONFIG = {
     email: true,
     phone: true,
     createdOn: true,
+    role: true,
+    organization: {
+      id: true,
+      organizationGeneral: {
+        alias: true,
+      },
+    },
   },
   searchableColumns: ['name'],
   defaultSortBy: 'name',
   defaultOrderDirection: OrderDirection.ASC,
-  relations: {},
+  relations: {
+    organization: {
+      organizationGeneral: true,
+    },
+  },
   rangeColumn: 'createdOn',
 };

--- a/backend/src/modules/user/constants/user-filters.config.ts
+++ b/backend/src/modules/user/constants/user-filters.config.ts
@@ -1,6 +1,6 @@
 import { OrderDirection } from 'src/common/enums/order-direction.enum';
 
-export const USER_FILTERS_CONFIG = {
+export const USER_APPLICATIONS_FILTERS_CONFIG = {
   selectColumns: {
     id: true,
     name: true,
@@ -10,6 +10,8 @@ export const USER_FILTERS_CONFIG = {
     status: true,
     availableApps: true,
     availableAppsIDs: true,
+    organizationId: true,
+    organizationAlias: true,
   },
   searchableColumns: ['name', 'email'],
   defaultSortBy: 'name',

--- a/backend/src/modules/user/services/user.service.ts
+++ b/backend/src/modules/user/services/user.service.ts
@@ -16,7 +16,7 @@ import {
   Not,
   UpdateResult,
 } from 'typeorm';
-import { USER_FILTERS_CONFIG } from '../constants/user-filters.config';
+import { USER_APPLICATIONS_FILTERS_CONFIG } from '../constants/user-filters.config';
 import { CreateUserDto } from '../dto/create-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
 import { UserFilterDto } from '../dto/user-filter.dto';
@@ -194,26 +194,7 @@ export class UserService {
 
     // For Admin user we will sort by organizationId
     return this.userApplicationsView.getManyPaginated(
-      USER_FILTERS_CONFIG,
-      organizationId
-        ? { ...paginationOptions, organizationId }
-        : paginationOptions,
-    );
-  }
-
-  public async findAll(
-    options: UserFilterDto,
-    organizationId?: number,
-  ): Promise<Pagination<User>> {
-    const paginationOptions: any = {
-      role: Role.EMPLOYEE,
-      status: `$in:${UserStatus.ACTIVE},${UserStatus.RESTRICTED}`,
-      ...options,
-    };
-
-    // For Admin user we will sort by organizationId
-    return this.userRepository.getManyPaginated(
-      USER_FILTERS_CONFIG,
+      USER_APPLICATIONS_FILTERS_CONFIG,
       organizationId
         ? { ...paginationOptions, organizationId }
         : paginationOptions,
@@ -353,7 +334,7 @@ export class UserService {
 
     // For Admin user we will sort by organizationId
     const users = await this.userApplicationsView.getManyPaginated(
-      USER_FILTERS_CONFIG,
+      USER_APPLICATIONS_FILTERS_CONFIG,
       organizationId
         ? { ...paginationOptions, organizationId }
         : paginationOptions,

--- a/frontend/src/assets/locales/en/translation.json
+++ b/frontend/src/assets/locales/en/translation.json
@@ -843,13 +843,16 @@
       "email": "E-mail",
       "phone": "Phone",
       "status": "General access",
-      "created": "Date added"
+      "created": "Date added",
+      "organizationAlias": "Organization"
     },
     "invites_header": {
       "name": "Name",
       "email": "E-mail",
       "phone": "Phone",
-      "added_on": "Date added"
+      "added_on": "Date added",
+      "role": "Role",
+      "organizationAlias": "Organization"
     },
     "status": {
       "active": "Activ",

--- a/frontend/src/assets/locales/ro/translation.json
+++ b/frontend/src/assets/locales/ro/translation.json
@@ -846,13 +846,16 @@
       "email": "E-mail",
       "phone": "Telefon",
       "status": "Acces general",
-      "created": "Data adăugării"
+      "created": "Data adăugării",
+      "organizationAlias": "Organizație"
     },
     "invites_header": {
       "name": "Nume",
       "email": "E-mail",
       "phone": "Telefon",
-      "added_on": "Data adăugării"
+      "added_on": "Data adăugării",
+      "role": "Rol",
+      "organizationAlias": "Organizație"
     },
     "status": {
       "active": "Activ",

--- a/frontend/src/common/router/Routes.constants.ts
+++ b/frontend/src/common/router/Routes.constants.ts
@@ -35,6 +35,7 @@ export const ADMIN_ROUTES = [
 export const SUPER_ADMIN_ROUTES = [
   { id: 0, name: translations.dashboard, href: '', icon: RectangleGroupIcon },
   { id: 1, name: translations.organizations, href: 'organizations', icon: CircleStackIcon },
-  { id: 2, name: translations.requests, href: 'requests', icon: UserPlusIcon },
-  { id: 3, name: translations.store, href: 'applications', icon: RectangleStackIcon },
+  { id: 2, name: translations.users, href: 'users/list', icon: UserGroupIcon },
+  { id: 3, name: translations.requests, href: 'requests', icon: UserPlusIcon },
+  { id: 4, name: translations.store, href: 'applications', icon: RectangleStackIcon },
 ];

--- a/frontend/src/pages/users/components/UserInvites/UserInvites.tsx
+++ b/frontend/src/pages/users/components/UserInvites/UserInvites.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { SortOrder, TableColumn } from 'react-data-table-component';
 import DataTableFilters from '../../../../components/data-table-filters/DataTableFilters';
 import DataTableComponent from '../../../../components/data-table/DataTableComponent';
@@ -10,13 +10,18 @@ import {
   useResendInviteMutation,
 } from '../../../../services/user/User.queries';
 import { useUser } from '../../../../store/selectors';
-import { UserInvitesTableHeaders } from './table-headers/UserInvitesTable.headers';
+import {
+  UserInvitesTableHeaderSuperAdmin,
+  UserInvitesTableHeaders,
+} from './table-headers/UserInvitesTable.headers';
 import { useTranslation } from 'react-i18next';
 import { ArrowUturnLeftIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { useErrorToast, useSuccessToast } from '../../../../common/hooks/useToast';
 import ConfirmationModal from '../../../../components/confim-removal-modal/ConfirmationModal';
 import { IInvite } from '../../interfaces/Invite.interface';
 import { OrderDirection } from '../../../../common/enums/sort-direction.enum';
+import { useAuthContext } from '../../../../contexts/AuthContext';
+import { UserRole } from '../../enums/UserRole.enum';
 
 const UserInvites = () => {
   const [isConfirmRemoveModalOpen, setIsConfirmRemoveModalOpen] = useState<boolean>(false);
@@ -28,6 +33,7 @@ const UserInvites = () => {
   const [orderByColumn, setOrderByColumn] = useState<string>();
   const [orderDirection, setOrderDirection] = useState<OrderDirection>();
 
+  const { role } = useAuthContext();
   const { invites } = useUser();
 
   const { t } = useTranslation(['user', 'common']);
@@ -52,6 +58,14 @@ const UserInvites = () => {
   useEffect(() => {
     if (selectedInviteeForDeletion) setIsConfirmRemoveModalOpen(true);
   }, [selectedInviteeForDeletion]);
+
+  const ListTableHeader = useMemo(() => {
+    if (role === UserRole.SUPER_ADMIN) {
+      return [...UserInvitesTableHeaderSuperAdmin, ...UserInvitesTableHeaders];
+    }
+
+    return UserInvitesTableHeaders;
+  }, [role]);
 
   const buildUserActionColumn = (): TableColumn<IInvite> => {
     const pendingUserMenuItems = [
@@ -164,7 +178,7 @@ const UserInvites = () => {
           </button> */}
         </div>
         <DataTableComponent
-          columns={[...UserInvitesTableHeaders, buildUserActionColumn()]}
+          columns={[...ListTableHeader, buildUserActionColumn()]}
           data={invites}
           loading={isLoading}
           sortServer

--- a/frontend/src/pages/users/components/UserInvites/table-headers/UserInvitesTable.headers.tsx
+++ b/frontend/src/pages/users/components/UserInvites/table-headers/UserInvitesTable.headers.tsx
@@ -10,6 +10,8 @@ const translations = {
   email: i18n.t('user:invites_header.email'),
   phone: i18n.t('user:invites_header.phone'),
   added_on: i18n.t('user:invites_header.added_on'),
+  organizationAlias: i18n.t('user:invites_header.organizationAlias'),
+  role: i18n.t('user:invites_header.role'),
 };
 
 export const UserInvitesTableHeaders: TableColumn<IInvite>[] = [
@@ -40,5 +42,26 @@ export const UserInvitesTableHeaders: TableColumn<IInvite>[] = [
     sortable: true,
     minWidth: '10rem',
     selector: (row: IInvite) => formatDate(row?.createdOn),
+  },
+];
+
+export const UserInvitesTableHeaderSuperAdmin: TableColumn<IInvite>[] = [
+  {
+    id: 'organization.organizationGeneral.alias',
+    name: <DataTableNameHeader text={translations.organizationAlias} />,
+    sortable: true,
+    grow: 1,
+    wrap: false,
+    minWidth: '15rem',
+    selector: (row: IInvite) => row.organization.organizationGeneral.alias,
+  },
+  {
+    id: 'role',
+    name: <DataTableNameHeader text={translations.role} />,
+    sortable: true,
+    grow: 1,
+    wrap: false,
+    minWidth: '10rem',
+    selector: (row: IInvite) => row.role,
   },
 ];

--- a/frontend/src/pages/users/components/UserList/table-headers/UserListTable.headers.tsx
+++ b/frontend/src/pages/users/components/UserList/table-headers/UserListTable.headers.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TableColumn } from 'react-data-table-component';
 import { formatDate } from '../../../../../common/helpers/format.helper';
 import StatusBadge, { BadgeStatus } from '../../../../../components/status-badge/StatusBadge';
-import { IUser } from '../../../interfaces/User.interface';
+import { IUserWithApplications } from '../../../interfaces/User.interface';
 import { UserStatus } from '../../../enums/UserStatus.enum';
 import i18n from '../../../../../common/config/i18n';
 import DataTableNameHeader from '../../../../../components/data-table-name-header/DataTableNameHeader';
@@ -15,9 +15,10 @@ const translations = {
   created: i18n.t('user:list_header.created'),
   active: i18n.t('user:status.active'),
   restricted: i18n.t('user:status.restricted'),
+  organizationAlias: i18n.t('user:list_header.organizationAlias'),
 };
 
-export const UserListTableHeaders: TableColumn<IUser>[] = [
+export const UserListTableHeaders: TableColumn<IUserWithApplications>[] = [
   {
     id: 'name',
     name: <DataTableNameHeader text={translations.name} />,
@@ -25,7 +26,7 @@ export const UserListTableHeaders: TableColumn<IUser>[] = [
     grow: 1,
     wrap: false,
     minWidth: '15rem',
-    selector: (row: IUser) => row.name,
+    selector: (row: IUserWithApplications) => row.name,
   },
   {
     id: 'email',
@@ -33,21 +34,21 @@ export const UserListTableHeaders: TableColumn<IUser>[] = [
     sortable: true,
     grow: 1,
     minWidth: '20rem',
-    selector: (row: IUser) => row.email,
+    selector: (row: IUserWithApplications) => row.email,
   },
   {
     id: 'phone',
     name: <DataTableNameHeader text={translations.phone} />,
     sortable: true,
     minWidth: '9rem',
-    selector: (row: IUser) => row.phone,
+    selector: (row: IUserWithApplications) => row.phone,
   },
   {
     id: 'availableApps',
     name: <DataTableNameHeader text="Access Aplicatii" />,
     sortable: false,
     minWidth: '15rem',
-    cell: (row: IUser) => (
+    cell: (row: IUserWithApplications) => (
       <div>
         {`(${row.availableApps.length})`}{' '}
         {row?.availableApps?.map((app, i) => (
@@ -62,7 +63,6 @@ export const UserListTableHeaders: TableColumn<IUser>[] = [
         ))}
       </div>
     ),
-    selector: (row: IUser) => row.availableAppsList || '',
   },
   {
     id: 'status',
@@ -70,7 +70,7 @@ export const UserListTableHeaders: TableColumn<IUser>[] = [
     sortField: 'status',
     name: <DataTableNameHeader text={translations.status} />,
     minWidth: '10rem',
-    cell: (row: IUser) => (
+    cell: (row: IUserWithApplications) => (
       <StatusBadge
         status={row.status === UserStatus.ACTIVE ? BadgeStatus.SUCCESS : BadgeStatus.ERROR}
         value={row.status === UserStatus.ACTIVE ? translations.active : translations.restricted}
@@ -82,6 +82,16 @@ export const UserListTableHeaders: TableColumn<IUser>[] = [
     minWidth: '10rem',
     name: <DataTableNameHeader text={translations.created} />,
     sortable: true,
-    selector: (row: IUser) => formatDate(row?.createdOn as string),
+    selector: (row: IUserWithApplications) => formatDate(row?.createdOn as string),
   },
 ];
+
+export const UserListTableHeaderOrganizationAlias: TableColumn<IUserWithApplications> = {
+  id: 'organizationAlias',
+  name: <DataTableNameHeader text={translations.organizationAlias} />,
+  sortable: true,
+  grow: 1,
+  wrap: false,
+  minWidth: '15rem',
+  selector: (row: IUserWithApplications) => row.organizationAlias,
+};

--- a/frontend/src/pages/users/interfaces/Invite.interface.ts
+++ b/frontend/src/pages/users/interfaces/Invite.interface.ts
@@ -4,4 +4,6 @@ export interface IInvite {
   email: string;
   phone: string;
   createdOn: Date;
+  role: string;
+  organization: { id: number; organizationGeneral: { alias: string } };
 }

--- a/frontend/src/pages/users/interfaces/User.interface.ts
+++ b/frontend/src/pages/users/interfaces/User.interface.ts
@@ -13,3 +13,14 @@ export interface IUser extends BaseEntity {
   availableAppsList?: string;
   availableApps: { id: number; name: string; type: string }[];
 }
+
+export interface IUserWithApplications extends BaseEntity {
+  name: string;
+  email: string;
+  phone: string;
+  status: UserStatus;
+  availableApps: { id: number; name: string; type: string }[];
+  availableAppsIDs: number[];
+  organizationId: number;
+  organizationAlias: string;
+}

--- a/frontend/src/services/organization/Organization.queries.ts
+++ b/frontend/src/services/organization/Organization.queries.ts
@@ -7,7 +7,10 @@ import { CompletionStatus } from '../../pages/organization/enums/CompletionStatu
 import { Contact } from '../../pages/organization/interfaces/Contact.interface';
 import { Expense } from '../../pages/organization/interfaces/Expense.interface';
 import { Income } from '../../pages/organization/interfaces/Income.interface';
-import { IOrganizationFull } from '../../pages/organization/interfaces/Organization.interface';
+import {
+  IOrganizationFull,
+  IOrganizationView,
+} from '../../pages/organization/interfaces/Organization.interface';
 import { IOrganizationActivity } from '../../pages/organization/interfaces/OrganizationActivity.interface';
 import { IOrganizationFinancial } from '../../pages/organization/interfaces/OrganizationFinancial.interface';
 import { IOrganizationGeneral } from '../../pages/organization/interfaces/OrganizationGeneral.interface';
@@ -78,7 +81,7 @@ export const useOrganizationsQuery = (
     () =>
       getOrganizations(limit, page, orderBy, orderDirection, search, status, interval, userCount),
     {
-      onSuccess: (data: PaginatedEntity<IOrganizationFull>) => {
+      onSuccess: (data: PaginatedEntity<IOrganizationView>) => {
         setOrganizations({
           items: data.items,
           meta: { ...data.meta, orderByColumn: orderBy, orderDirection },

--- a/frontend/src/services/user/User.queries.ts
+++ b/frontend/src/services/user/User.queries.ts
@@ -14,7 +14,7 @@ import {
 import { useMutation, useQuery } from 'react-query';
 import useStore from '../../store/store';
 import { IUserPayload } from '../../pages/users/interfaces/UserPayload.interface';
-import { IUser } from '../../pages/users/interfaces/User.interface';
+import { IUserWithApplications } from '../../pages/users/interfaces/User.interface';
 import { PaginatedEntity } from '../../common/interfaces/paginated-entity.interface';
 import { OrderDirection } from '../../common/enums/sort-direction.enum';
 import { UserStatus } from '../../pages/users/enums/UserStatus.enum';
@@ -72,7 +72,7 @@ export const useUsersQuery = (
         availableAppsIDs?.map((app) => app.id),
       ),
     {
-      onSuccess: (data: PaginatedEntity<IUser>) => {
+      onSuccess: (data: PaginatedEntity<IUserWithApplications>) => {
         setUsers({
           items: data.items,
           meta: { ...data.meta, orderByColumn: orderBy, orderDirection },

--- a/frontend/src/services/user/User.service.ts
+++ b/frontend/src/services/user/User.service.ts
@@ -1,10 +1,9 @@
-import { AxiosResponseHeaders } from 'axios';
 import { formatISO9075 } from 'date-fns';
 import { OrderDirection } from '../../common/enums/sort-direction.enum';
 import { PaginatedEntity } from '../../common/interfaces/paginated-entity.interface';
 import { UserStatus } from '../../pages/users/enums/UserStatus.enum';
 import { IInvite } from '../../pages/users/interfaces/Invite.interface';
-import { IUser } from '../../pages/users/interfaces/User.interface';
+import { IUser, IUserWithApplications } from '../../pages/users/interfaces/User.interface';
 import { IUserPayload } from '../../pages/users/interfaces/UserPayload.interface';
 import API from '../API';
 
@@ -64,7 +63,7 @@ export const getUsers = async (
   interval?: Date[],
   organizationId?: number,
   availableAppsIDs?: number[],
-): Promise<PaginatedEntity<IUser>> => {
+): Promise<PaginatedEntity<IUserWithApplications>> => {
   let requestUrl = `/user?limit=${limit}&page=${page}&orderBy=${orderBy}&orderDirection=${orderDirection}`;
 
   if (search) requestUrl = `${requestUrl}&search=${search}`;

--- a/frontend/src/store/organization/organizations.slice.ts
+++ b/frontend/src/store/organization/organizations.slice.ts
@@ -1,6 +1,9 @@
 import { OrderDirection } from '../../common/enums/sort-direction.enum';
 import { PaginatedEntity } from '../../common/interfaces/paginated-entity.interface';
-import { IOrganizationFull } from '../../pages/organization/interfaces/Organization.interface';
+import {
+  IOrganizationFull,
+  IOrganizationView,
+} from '../../pages/organization/interfaces/Organization.interface';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const organizationsSlice = (set: any) => ({
@@ -16,7 +19,7 @@ export const organizationsSlice = (set: any) => ({
       orderDirection: OrderDirection.ASC,
     },
   },
-  setOrganizations: (organizations: PaginatedEntity<IOrganizationFull>) => {
+  setOrganizations: (organizations: PaginatedEntity<IOrganizationView>) => {
     set({ organizations });
   },
 });

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -16,10 +16,11 @@ import { Federation } from '../common/interfaces/federations.interface';
 import { organizationLegalSlice } from './organization/organization-legal.slice';
 import { organizationReportsSlice } from './organization/organization-reports.slice';
 import { profileSlice } from './user/Profile.slice';
-import { IUser } from '../pages/users/interfaces/User.interface';
+import { IUser, IUserWithApplications } from '../pages/users/interfaces/User.interface';
 import {
   IOrganization,
   IOrganizationFull,
+  IOrganizationView,
 } from '../pages/organization/interfaces/Organization.interface';
 import { organizationSlice } from './organization/organization.slice';
 import { usersSlice } from './user/Users.slice';
@@ -47,7 +48,7 @@ import { IFeedback } from '../pages/civic-center-service/interfaces/Feedback.int
 import { feedbacksSlice } from './civic-center-service/Feedback.slice';
 
 interface OrganizationState {
-  organizations: PaginatedEntity<IOrganizationFull>;
+  organizations: PaginatedEntity<IOrganizationView>;
   organization: IOrganization | null;
   organizationGeneral: IOrganizationGeneral | null;
   organizationFinancial: IOrganizationFinancial[];
@@ -60,7 +61,7 @@ interface OrganizationState {
   setOrganizationFinancial: (organizationFinancial: IOrganizationFinancial[]) => void;
   setOrganizationReport: (organizationReport: IOrganizationReport) => void;
   setOrganizationLegal: (organizationLegal: IOrganizationLegal) => void;
-  setOrganizations: (organizations: PaginatedEntity<IOrganizationFull>) => void;
+  setOrganizations: (organizations: PaginatedEntity<IOrganizationView>) => void;
 }
 interface NomenclatureState {
   counties: County[];
@@ -87,8 +88,8 @@ interface ProfileState {
 }
 
 interface UserState {
-  users: PaginatedEntity<IUser>;
-  setUsers: (users: PaginatedEntity<IUser>) => void;
+  users: PaginatedEntity<IUserWithApplications>;
+  setUsers: (users: PaginatedEntity<IUserWithApplications>) => void;
 }
 
 interface InviteState {

--- a/frontend/src/store/user/Users.slice.ts
+++ b/frontend/src/store/user/Users.slice.ts
@@ -1,6 +1,6 @@
 import { OrderDirection } from '../../common/enums/sort-direction.enum';
 import { PaginatedEntity } from '../../common/interfaces/paginated-entity.interface';
-import { IUser } from '../../pages/users/interfaces/User.interface';
+import { IUserWithApplications } from '../../pages/users/interfaces/User.interface';
 
 export const usersSlice = (set: any) => ({
   users: {
@@ -15,7 +15,7 @@ export const usersSlice = (set: any) => ({
       orderDirection: OrderDirection.ASC,
     },
   },
-  setUsers: (users: PaginatedEntity<IUser>) => {
+  setUsers: (users: PaginatedEntity<IUserWithApplications>) => {
     set({ users });
   },
 });


### PR DESCRIPTION
SuperAdmins can view "Utilizatori" tab.
The table will display all users from all organizations filtered by the same tabs (Utilizatori / Invitatii Trimise)
SuperAdmins will have 2 more columns: Organization and Role (only in Invitatii Trimise).

Fixes #493 